### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/BenAhrdt/ioBroker.drag-indicator"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "node-schedule": "^2.1.1"


### PR DESCRIPTION
Adapter requires node 16 as adapter-core 3.x.x is known to fail at node 14 or older